### PR TITLE
feat: add amplify.yml for AWS Amplify Hosting V2 (openclaw-aws-setup #43)

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,18 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - npm install -g pnpm
+        - pnpm install
+    build:
+      commands:
+        - pnpm run build
+  artifacts:
+    baseDirectory: .next
+    files:
+      - "**/*"
+  cache:
+    paths:
+      - node_modules/**/*
+      - .next/cache/**/*


### PR DESCRIPTION
## 概要
AWS Amplify Hosting V2でのデプロイ設定を追加。
Vercelの代替として、CI/CD自動デプロイ環境を構築。

## 変更内容
- `amplify.yml` 追加：pnpm + Next.js SSR ビルド設定

## Amplify設定状況
- App ID: `d31242v30hmgzh`
- App名: `openclaw-mac-store`
- Branch: `main` (PRODUCTION)
- 環境変数: `STRIPE_SECRET_KEY`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`, `NEXT_PUBLIC_SITE_URL` 設定済み

## 残課題
- GitHub ↔ Amplify OAuthトークン連携（要AWS Console操作 or GitHub PAT）
- 初回デプロイ実行

## 関連
- openclaw-aws-setup #43