### PR TITLE
fix: CI pnpm cache エラー修正 closes #14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install
       - run: pnpm lint
       - run: pnpm test --run

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver


### PR DESCRIPTION
## 修正内容
- `actions/setup-node@v4` に `cache-dependency-path: pnpm-lock.yaml` を追加
- `pnpm-workspace.yaml` に `packages` フィールドを追加（`packages field missing or empty` エラーの根本原因）
- `packages field missing or empty` エラーを解消

closes #14