### PR TITLE
fix: LP全セクション表示修正 + Tailwindカスタムカラー安定化 refs #18

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@source "../../**/*.{ts,tsx}";
 
 :root {
   --background: #ffffff;
@@ -11,13 +12,13 @@
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 
-  /* Brand colors */
+  /* Brand colors — キャメルケースでクラス名と一致させる */
   --color-brand-bg: #0a0a0a;
-  --color-brand-bg-light: #ffffff;
+  --color-brand-bgLight: #ffffff;
   --color-brand-accent: #6366f1;
-  --color-brand-accent-hover: #4f46e5;
-  --color-brand-text-dark: #f5f5f7;
-  --color-brand-text-light: #1d1d1f;
+  --color-brand-accentHover: #4f46e5;
+  --color-brand-textDark: #f5f5f7;
+  --color-brand-textLight: #1d1d1f;
   --color-brand-border: rgba(255, 255, 255, 0.1);
 }
 


### PR DESCRIPTION
## 変更内容

### 根本原因
Tailwind v4 では `tailwind.config.ts` の `content` フィールドは使われず、CSS の `@source` ディレクティブでコンテンツスキャンを設定する必要がある。
また `@theme` の変数名（`--color-brand-text-dark`）がコンポーネントのキャメルケースクラス名（`text-brand-textDark`）と不一致だった。

### 修正内容
- `globals.css`: `@source` ディレクティブ追加（v4でのコンテンツスキャン保証）
- `globals.css`: `@theme` ブランドカラー変数名をキャメルケース統一（`--color-brand-textDark` 等）

### 確認済み
- `pnpm build` ✅
- `pnpm test --run` 21/21 Pass ✅
- CI: ✅ success

refs #18